### PR TITLE
Refactor/reduce globally managed state

### DIFF
--- a/frontend/src/components/molecule/ChannelBrowserCard/ChannelBrowserCard.js
+++ b/frontend/src/components/molecule/ChannelBrowserCard/ChannelBrowserCard.js
@@ -4,7 +4,7 @@ import Button from '../../atom/Button'
 import Description from '../../atom/Description'
 import { useHistory, useParams } from 'react-router'
 import { leaveChannel, joinChannel } from '../../../api/channel'
-import { workspaceRecoil, useSetChannels } from '../../../store'
+import { useRefreshChannels, workspaceQuery } from '../../../store'
 import { COLOR } from '../../../constant/style'
 import { useRecoilValue } from 'recoil'
 
@@ -17,8 +17,8 @@ function ChannelBrowserCard({
   workspaceUserInfoId,
 }) {
   const { workspaceId, channelId } = useParams()
-  const setChannels = useSetChannels()
-  const workspaceUserInfo = useRecoilValue(workspaceRecoil)
+  const workspaceUserInfo = useRecoilValue(workspaceQuery(workspaceId))
+  const refreshChannels = useRefreshChannels(workspaceId)
   const history = useHistory()
   const defaultChannel = workspaceUserInfo.workspaceInfo.default_channel
 
@@ -37,7 +37,7 @@ function ChannelBrowserCard({
         channelId: _id,
       })
     }
-    setChannels()
+    refreshChannels()
     handleClose()
   }
   const createButton = () => {

--- a/frontend/src/components/molecule/ChannelStarButton/ChannelStarButton.js
+++ b/frontend/src/components/molecule/ChannelStarButton/ChannelStarButton.js
@@ -1,12 +1,12 @@
 import React, { useState } from 'react'
-import { useHistory } from 'react-router'
+import { useHistory, useParams } from 'react-router'
 import { toast } from 'react-toastify'
 import { useRecoilValue } from 'recoil'
 
 import Icon from '../../atom/Icon'
 import request from '../../../util/request'
 import { COLOR } from '../../../constant/style'
-import { workspaceRecoil, useSetChannels } from '../../../store'
+import { useRefreshChannels, workspaceQuery } from '../../../store'
 import { STAR, COLOREDSTAR } from '../../../constant/icon'
 import { isEmpty } from '../../../util'
 
@@ -17,8 +17,11 @@ function ChannelStarButton({
   },
 }) {
   const [sectionInfo, setSectionInfo] = useState(sectionName)
-  const setChannels = useSetChannels()
-  const { _id: workspaceUserInfoId } = useRecoilValue(workspaceRecoil)
+  const { workspaceId } = useParams()
+  const refreshChannels = useRefreshChannels(workspaceId)
+  const { _id: workspaceUserInfoId } = useRecoilValue(
+    workspaceQuery(workspaceId),
+  )
   const history = useHistory()
 
   const updateSection = async () => {
@@ -33,7 +36,7 @@ function ChannelStarButton({
       })
 
       if (data.success) setSectionInfo(currentSectionName)
-      setChannels()
+      refreshChannels()
     } catch (err) {
       toast.error('채널 섹션 정보를 가져오는데 오류가 발생했습니다.', {
         onClose: () => history.goBack(),

--- a/frontend/src/components/organism/ChannelHeader/ChannelHeader.js
+++ b/frontend/src/components/organism/ChannelHeader/ChannelHeader.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { useSetRecoilState, useRecoilValue } from 'recoil'
+import { useParams } from 'react-router-dom'
 
 import Icon from '../../atom/Icon'
 import { ADDUSER, INFOCIRCLE, LOCK, HASHTAG } from '../../../constant/icon'
@@ -8,7 +9,7 @@ import ChannelCard from '../../molecule/ChannelCard'
 import ChannelStarButton from '../../molecule/ChannelStarButton'
 import ChannelTopicButton from '../../molecule/ChannelTopicButton'
 import ChannelMemberThumbnail from '../../molecule/ChannelMemberThumbnail'
-import { modalRecoil, currentChannelInfoRecoil } from '../../../store'
+import { modalRecoil, channelInfoQuery } from '../../../store'
 import InviteUserToChannelModal from '../Modal/InviteUserToChannelModal'
 import dmTitleGenerator from '../../../util/dmTitleGenerator'
 import { COLOR } from '../../../constant/style'
@@ -17,7 +18,10 @@ import { THUMBTACK } from '../../../constant/icon'
 
 function ChannelHeader() {
   const setModal = useSetRecoilState(modalRecoil)
-  const channelInfo = useRecoilValue(currentChannelInfoRecoil)
+  const { workspaceId, channelId } = useParams()
+  const channelInfo = useRecoilValue(
+    channelInfoQuery({ workspaceId, channelId }),
+  )
   const openAddUserModal = () => {
     setModal(<InviteUserToChannelModal handleClose={() => setModal(null)} />)
   }

--- a/frontend/src/components/organism/ChatMessage/ChatMessage.js
+++ b/frontend/src/components/organism/ChatMessage/ChatMessage.js
@@ -10,7 +10,7 @@ import ActionBar from '../ActionBar'
 import ViewThreadButton from '../../molecule/ViewThreadButton'
 import { isEmpty } from '../../../util'
 import { SIZE, COLOR } from '../../../constant/style'
-import { workspaceRecoil, socketRecoil } from '../../../store'
+import { workspaceQuery, socketRecoil } from '../../../store'
 import FilePreview from '../../molecule/FilePreview'
 import { SOCKET_EVENT } from '../../../constant'
 const ChatMessage = forwardRef(
@@ -31,7 +31,7 @@ const ChatMessage = forwardRef(
     const { workspaceId, channelId } = useParams()
     const [openModal, setOpenModal] = useState(false)
     const [hover, setHover] = useState(false)
-    const workspaceUserInfo = useRecoilValue(workspaceRecoil)
+    const workspaceUserInfo = useRecoilValue(workspaceQuery(workspaceId))
     const socket = useRecoilValue(socketRecoil)
 
     const updateReaction = ({ emoji, chatId, channelId, type }) => {

--- a/frontend/src/components/organism/ChatRoom/ChatRoom.js
+++ b/frontend/src/components/organism/ChatRoom/ChatRoom.js
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react'
+import React, {
+  useEffect,
+  useState,
+  useRef,
+  useCallback,
+  Suspense,
+} from 'react'
 import styled from 'styled-components'
 import { useParams } from 'react-router-dom'
 import { useRecoilValue } from 'recoil'
@@ -283,5 +289,12 @@ const UnreadMessage = styled.div`
 const MessageEnd = styled.div`
   min-height: 1px;
 `
+const Content = ({ width }) => {
+  return (
+    <Suspense fallback={<ChatArea width={width} />}>
+      <ChatRoom width={width} />
+    </Suspense>
+  )
+}
 
-export default ChatRoom
+export default Content

--- a/frontend/src/components/organism/Modal/ChannelBrowserModal/ChannelBrowserModal.js
+++ b/frontend/src/components/organism/Modal/ChannelBrowserModal/ChannelBrowserModal.js
@@ -4,7 +4,7 @@ import { useRecoilValue } from 'recoil'
 import ChannelBrowserCard from '../../../molecule/ChannelBrowserCard'
 import { useParams } from 'react-router-dom'
 
-import { workspaceRecoil } from '../../../../store'
+import { workspaceQuery } from '../../../../store'
 import Modal from '../../../atom/Modal'
 import H, { defaultH1Style } from '../../../atom/H'
 import Icon from '../../../atom/Icon'
@@ -15,8 +15,8 @@ import { COLOR } from '../../../../constant/style'
 
 function ChannelBrowserModal({ handleClose }) {
   const [channelList, setChannelList] = useState([])
-  const workspaceUserInfo = useRecoilValue(workspaceRecoil)
   const { workspaceId } = useParams()
+  const workspaceUserInfo = useRecoilValue(workspaceQuery(workspaceId))
 
   useEffect(() => {
     if (workspaceUserInfo) {

--- a/frontend/src/components/organism/Modal/CreateChannelModal/CreateChannelModal.js
+++ b/frontend/src/components/organism/Modal/CreateChannelModal/CreateChannelModal.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { useRecoilValue } from 'recoil'
 import { useHistory, useParams } from 'react-router-dom'
 
-import { workspaceRecoil, useSetChannels } from '../../../../store'
+import { workspaceQuery, useRefreshChannels } from '../../../../store'
 import Modal from '../../../atom/Modal'
 import H, { defaultH1Style } from '../../../atom/H'
 import Icon from '../../../atom/Icon'
@@ -32,8 +32,11 @@ const DUPLICATED_NAME_ERROR =
 const CreateChannelModal = ({ handleClose }) => {
   const history = useHistory()
   const { workspaceId } = useParams()
-  const { _id: workspaceUserInfoId } = useRecoilValue(workspaceRecoil)
-  const setChannels = useSetChannels()
+  const refreshChannels = useRefreshChannels(workspaceId)
+  const { _id: workspaceUserInfoId } = useRecoilValue(
+    workspaceQuery(workspaceId),
+  )
+
   const [isPrivate, setPrivateOption] = useState(false)
   const [channelName, setChannelName] = useState('')
   const [channelDescription, setChannelDescription] = useState('')
@@ -58,7 +61,7 @@ const CreateChannelModal = ({ handleClose }) => {
       description: channelDescription,
       workspaceId,
     })
-    setChannels()
+    refreshChannels()
     history.push(`/workspace/${workspaceId}/${channelId}`)
     handleClose()
   }

--- a/frontend/src/components/organism/Modal/InviteUserToChannelModal/InviteUserToChannelModal.js
+++ b/frontend/src/components/organism/Modal/InviteUserToChannelModal/InviteUserToChannelModal.js
@@ -11,9 +11,9 @@ import SelectedUserCard from '../../../molecule/SelectedUserCard'
 import SearchUserList from '../../../molecule/SearchUserList'
 import ChannelCard from '../../../molecule/ChannelCard'
 import {
-  workspaceRecoil,
-  currentChannelInfoRecoil,
-  useSetChannels,
+  channelInfoQuery,
+  workspaceQuery,
+  useRefreshChannels,
 } from '../../../../store'
 import { createChannel, findChannelIdByName } from '../../../../api/channel'
 import { getWorkspaceUserInfoByInfoId } from '../../../../api/workspace'
@@ -24,16 +24,20 @@ import { LOCK, HASHTAG, CLOSE } from '../../../../constant/icon'
 import { SOCKET_EVENT } from '../../../../constant'
 
 function InviteUserToChannelModal({ handleClose, type = 'channel' }) {
-  const channelInfo = useRecoilValue(currentChannelInfoRecoil)
   const setModal = useSetRecoilState(modalRecoil)
   const socket = useRecoilValue(socketRecoil)
   const [searchResult, setSearchResult] = useState(null)
   const [inviteUserList, setInviteUserList] = useState([])
-  const { workspaceId } = useParams()
-  const { _id: workspaceUserInfoId } = useRecoilValue(workspaceRecoil)
-  const history = useHistory()
-  const setChannels = useSetChannels()
+  const { workspaceId, channelId } = useParams()
+  const { _id: workspaceUserInfoId } = useRecoilValue(
+    workspaceQuery(workspaceId),
+  )
 
+  const history = useHistory()
+  const channelInfo = useRecoilValue(
+    channelInfoQuery({ workspaceId, channelId }),
+  )
+  const refreshChannels = useRefreshChannels(workspaceId)
   const SearchUser = async search => {
     if (search.length === 0) return setSearchResult(null)
     const { data } = await request.POST('/api/search/user', {
@@ -94,8 +98,7 @@ function InviteUserToChannelModal({ handleClose, type = 'channel' }) {
       })
       setModal(null)
     }
-
-    setChannels()
+    refreshChannels()
     history.push(`/workspace/${workspaceId}/${channelId}`)
   }
 

--- a/frontend/src/components/organism/SideBar/SideBar.js
+++ b/frontend/src/components/organism/SideBar/SideBar.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 import styled from 'styled-components'
 import ChannelSection from '../ChannelSection'
 import StaticSideMenuCard from '../../molecule/StaticSideMenuCard'
@@ -128,4 +128,11 @@ const NameArea = styled.div`
   text-overflow: ellipsis;
   overflow: hidden;
 `
-export default SideBar
+const Content = ({ width }) => {
+  return (
+    <Suspense fallback={<SideBarContainer width={width} />}>
+      <SideBar width={width} />
+    </Suspense>
+  )
+}
+export default Content

--- a/frontend/src/components/organism/SideBar/SideBar.js
+++ b/frontend/src/components/organism/SideBar/SideBar.js
@@ -3,8 +3,10 @@ import styled from 'styled-components'
 import ChannelSection from '../ChannelSection'
 import StaticSideMenuCard from '../../molecule/StaticSideMenuCard'
 import Icon from '../../atom/Icon'
+import { useParams } from 'react-router'
+
 import Button, { whiteButtonStyle } from '../../atom/Button'
-import { workspaceRecoil, sectionRecoil } from '../../../store'
+import { sectionsFromChannels, workspaceQuery } from '../../../store'
 import { COLOR } from '../../../constant/style'
 import {
   EDIT,
@@ -18,8 +20,9 @@ import {
 import { useRecoilValue } from 'recoil'
 
 function SideBar({ width }) {
-  const sections = useRecoilValue(sectionRecoil)
-  const workspaceUserInfo = useRecoilValue(workspaceRecoil)
+  const { workspaceId } = useParams()
+  const sections = useRecoilValue(sectionsFromChannels(workspaceId))
+  const workspaceUserInfo = useRecoilValue(workspaceQuery(workspaceId))
   return (
     <SideBarContainer width={width}>
       {workspaceUserInfo !== null && (

--- a/frontend/src/components/organism/ThreadSideBar/ThreadSideBar.js
+++ b/frontend/src/components/organism/ThreadSideBar/ThreadSideBar.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, Suspense } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
 import { useRecoilValue } from 'recoil'
 import styled from 'styled-components'
@@ -12,6 +12,7 @@ import { CLOSE } from '../../../constant/icon'
 import { SOCKET_EVENT } from '../../../constant'
 import { socketRecoil, workspaceQuery } from '../../../store'
 import { hasMyReaction, chageReactionState } from '../../../util/reactionUpdate'
+
 function ThreadSideBar({ sidebarWidth, setSidebarWidth }) {
   const { workspaceId, channelId, chatId } = useParams()
   const [sidebarChat, setSidebarChat] = useState(null)
@@ -211,4 +212,14 @@ const CountReplyArea = styled.div`
   padding: 16px;
   align-items: center;
 `
-export default ThreadSideBar
+const Content = ({ sidebarWidth, setSidebarWidth }) => {
+  return (
+    <Suspense fallback={<ThreadSideBarContainer width={sidebarWidth} />}>
+      <ThreadSideBar
+        sidebarWidth={sidebarWidth}
+        setSidebarWidth={setSidebarWidth}
+      />
+    </Suspense>
+  )
+}
+export default Content

--- a/frontend/src/components/organism/ThreadSideBar/ThreadSideBar.js
+++ b/frontend/src/components/organism/ThreadSideBar/ThreadSideBar.js
@@ -10,7 +10,7 @@ import { getChatReplyMessage } from '../../../api/chat'
 import { COLOR } from '../../../constant/style'
 import { CLOSE } from '../../../constant/icon'
 import { SOCKET_EVENT } from '../../../constant'
-import { workspaceRecoil, socketRecoil } from '../../../store'
+import { socketRecoil, workspaceQuery } from '../../../store'
 import { hasMyReaction, chageReactionState } from '../../../util/reactionUpdate'
 function ThreadSideBar({ sidebarWidth, setSidebarWidth }) {
   const { workspaceId, channelId, chatId } = useParams()
@@ -18,7 +18,8 @@ function ThreadSideBar({ sidebarWidth, setSidebarWidth }) {
   const [replyContent, setReplyContent] = useState(null)
   const socket = useRecoilValue(socketRecoil)
   const messageEndRef = useRef()
-  const workspaceUserInfo = useRecoilValue(workspaceRecoil)
+  const workspaceUserInfo = useRecoilValue(workspaceQuery(workspaceId))
+
   const history = useHistory()
 
   useEffect(() => {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom'
 import WorkspacePage from './page/WorkspacePage'
 import { BrowserRouter, Route } from 'react-router-dom'
@@ -28,12 +28,10 @@ const App = () => {
             path="/create-workspace"
             component={Auth(CreateWorkspace, true)}
           />
-          <Suspense fallback={<div>loading...</div>}>
-            <Route
-              path="/workspace/:workspaceId/:channelId"
-              component={Auth(WorkspacePage, true)}
-            />
-          </Suspense>
+          <Route
+            path="/workspace/:workspaceId/:channelId"
+            component={Auth(WorkspacePage, true)}
+          />
         </BrowserRouter>
       </RecoilRoot>
     </React.StrictMode>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 import ReactDOM from 'react-dom'
 import WorkspacePage from './page/WorkspacePage'
 import { BrowserRouter, Route } from 'react-router-dom'
@@ -28,10 +28,12 @@ const App = () => {
             path="/create-workspace"
             component={Auth(CreateWorkspace, true)}
           />
-          <Route
-            path="/workspace/:workspaceId/:channelId"
-            component={Auth(WorkspacePage, true)}
-          />
+          <Suspense fallback={<div>loading...</div>}>
+            <Route
+              path="/workspace/:workspaceId/:channelId"
+              component={Auth(WorkspacePage, true)}
+            />
+          </Suspense>
         </BrowserRouter>
       </RecoilRoot>
     </React.StrictMode>

--- a/frontend/src/page/WorkspacePage/WorkspacePage.js
+++ b/frontend/src/page/WorkspacePage/WorkspacePage.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, Suspense } from 'react'
 import styled from 'styled-components'
 import { useParams, Route } from 'react-router-dom'
 import { useRecoilValue } from 'recoil'
-import { modalRecoil, useInitializeAtoms } from '../../store'
+import { modalRecoil, useSocket } from '../../store'
 
 import SideBar from '../../components/organism/SideBar'
 import ChatRoom from '../../components/organism/ChatRoom'
@@ -14,11 +14,10 @@ import DraggableBoundaryLine from '../../components/molecule/DraggableBoundaryLi
 import GlobalHeader from '../../components/organism/GlobalHeader'
 
 function WorkspacePage() {
-  const { channelId, workspaceId } = useParams()
+  const { channelId } = useParams()
   const [listWidth, setListWidth] = useState(250)
   const [sidebarWidth, setSidebarWidth] = useState(0)
   const modal = useRecoilValue(modalRecoil)
-  useInitializeAtoms(workspaceId)
   useEffect(() => {
     if (Notification.permission !== 'denied') {
       Notification.requestPermission()
@@ -46,10 +45,12 @@ function WorkspacePage() {
       {modal}
       <GlobalHeader />
       <MainArea>
-        <SideBar width={listWidth} />
+        <Suspense fallback={<div>loading...</div>}>
+          <SideBar width={listWidth} />
+        </Suspense>
         <DraggableBoundaryLine setWidth={setListWidth} min="150" max="450" />
         <ContentsArea width={listWidth}>
-          {switching()}
+          <Suspense fallback={<div>loading...</div>}>{switching()}</Suspense>
 
           <Route exact path={'/workspace/:workspaceId/:channelId/:chatId'}>
             <ThreadSideBar

--- a/frontend/src/page/WorkspacePage/WorkspacePage.js
+++ b/frontend/src/page/WorkspacePage/WorkspacePage.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, Suspense } from 'react'
 import styled from 'styled-components'
 import { useParams, Route } from 'react-router-dom'
 import { useRecoilValue } from 'recoil'
-import { modalRecoil, useSocket } from '../../store'
+import { modalRecoil, useInitSocket } from '../../store'
 
 import SideBar from '../../components/organism/SideBar'
 import ChatRoom from '../../components/organism/ChatRoom'
@@ -45,13 +45,10 @@ function WorkspacePage() {
       {modal}
       <GlobalHeader />
       <MainArea>
-        <Suspense fallback={<div>loading...</div>}>
-          <SideBar width={listWidth} />
-        </Suspense>
+        <SideBar width={listWidth} />
         <DraggableBoundaryLine setWidth={setListWidth} min="150" max="450" />
         <ContentsArea width={listWidth}>
-          <Suspense fallback={<div>loading...</div>}>{switching()}</Suspense>
-
+          {switching()}
           <Route exact path={'/workspace/:workspaceId/:channelId/:chatId'}>
             <ThreadSideBar
               sidebarWidth={sidebarWidth}


### PR DESCRIPTION
## 공유할 사항
- 서버의 응답 값을 반드시 전역 상태로 관리 할 필요성이 없다는 것을 배우고, 캐싱되는 recoil의 selectorFamily를 이용하여 "저장"하는 전역 상태 값들을 줄임
- 간단한 skeleton ui를 추가하여 데이터를 가져오는 동안 컨텐츠를 표시하여 ux 개선
### 참고
- https://jbee.io/react/thinking-about-global-state/
- https://www.youtube.com/watch?v=FvRtoViujGg